### PR TITLE
Create new system for speeding up spawn rate

### DIFF
--- a/Assets/GameStatics.prefab
+++ b/Assets/GameStatics.prefab
@@ -43,8 +43,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c2535a750bab8742894f796fb04233e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  x: 60
-  phase: 1
+  minX: 20
+  startX: 20
+  x: 20
+  phase: 4
+  minPhase: 4
+  game: 1
   gameState: 1
   HighScores:
   - 0
@@ -73,3 +77,5 @@ MonoBehaviour:
   currentUser: Player 1
   hasPowerUp: 0
   powerUpCountdown: 20
+  pointCountdown: 5
+  pointValue: 20

--- a/Assets/MainGame.unity
+++ b/Assets/MainGame.unity
@@ -692,7 +692,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 28.45
+  m_fontSize: 33.65
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -866,7 +866,7 @@ PrefabInstance:
     - target: {fileID: 114590611587045786, guid: 0be297af096cdff4eb4827320b65edd3,
         type: 3}
       propertyPath: phase
-      value: 1
+      value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0be297af096cdff4eb4827320b65edd3, type: 3}
@@ -955,7 +955,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 30.85
+  m_fontSize: 36.5
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1360,7 +1360,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 44.45
+  m_fontSize: 52.6
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1578,7 +1578,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 56.25
+  m_fontSize: 52.6
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1952,7 +1952,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 41.45
+  m_fontSize: 49.05
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -2485,7 +2485,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 44.45
+  m_fontSize: 52.6
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1

--- a/Assets/Menu.unity
+++ b/Assets/Menu.unity
@@ -433,7 +433,7 @@ PrefabInstance:
     - target: {fileID: 114590611587045786, guid: 0be297af096cdff4eb4827320b65edd3,
         type: 3}
       propertyPath: phase
-      value: 1
+      value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0be297af096cdff4eb4827320b65edd3, type: 3}
@@ -522,7 +522,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 25.7
+  m_fontSize: 35.05
   m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -709,7 +709,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 25.7
+  m_fontSize: 35.05
   m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1297,7 +1297,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 25.7
+  m_fontSize: 35.05
   m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1727,7 +1727,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 51.4
+  m_fontSize: 70.15
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1844,7 +1844,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 14.05
+  m_fontSize: 23.45
   m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 1

--- a/Assets/Scripts/DungeonMaster.cs
+++ b/Assets/Scripts/DungeonMaster.cs
@@ -9,7 +9,9 @@ public class DungeonMaster : MonoBehaviour {
 	private float timer;
 	private float timer2;
 	private float timer3;
+    private float phaseCounter;
     private int curScore;
+    private int subtractor = 0;
 	public TextMeshProUGUI Score;
 	public TextMeshProUGUI CheckPoint;
 	public TextMeshProUGUI HighScore;
@@ -23,10 +25,22 @@ public class DungeonMaster : MonoBehaviour {
 		timer  = 0.0f;
 		timer2 = 0.0f;
 		timer3 = 0.0f;
+        phaseCounter = 0.0f;
         curScore  = 0;
         Statics.masterMind.pointCountdown = 5.0f;
         Statics.masterMind.powerUpCountdown = 20.0f;
 
+    }
+
+    public void resetPhase()
+    {
+        timer = 0.0f;
+        timer2 = 0.0f;
+        timer3 = 0.0f;
+        phaseCounter = 0.0f;
+        Statics.masterMind.pointCountdown = 5.0f;
+        Statics.masterMind.powerUpCountdown = 20.0f;
+        Statics.masterMind.x = Statics.masterMind.minX;
     }
 
     public void scorePoints(int points)
@@ -67,6 +81,7 @@ public class DungeonMaster : MonoBehaviour {
 				timer=0.0f;
 				timer2=0.0f;
 				timer3=0.0f;
+                phaseCounter = 0.0f;
 			}
 			
 		}
@@ -82,19 +97,24 @@ public class DungeonMaster : MonoBehaviour {
             }
 			timer2+=Time.fixedDeltaTime;
 			timer3+=Time.fixedDeltaTime;
+            phaseCounter += Time.fixedDeltaTime;
 			Score.text=curScore.ToString();
 			HighScore.text=(Mathf.Floor(Statics.masterMind.HighScores[0]*10)/10).ToString();
-			CheckPoint.text=(Statics.masterMind.phase).ToString();
-			
-			if(Statics.masterMind.x<=20)//WIP - resets x when the phase increases
+			CheckPoint.text=(Statics.masterMind.phase-(Statics.masterMind.minPhase-1)).ToString();
+
+            
+
+			if(phaseCounter>=Statics.masterMind.startX)//WIP - resets x when the phase increases
 			{
 				Statics.masterMind.phase++;
 				if(Statics.masterMind.phase>7)
 				{
 					Statics.masterMind.phase=7;
 				}
-				Statics.masterMind.x=60;
-			}
+                Statics.masterMind.x = Statics.masterMind.minX;
+                phaseCounter -= Statics.masterMind.startX;
+
+            }
 
             if (!Statics.masterMind.hasPowerUp)
             {
@@ -113,19 +133,31 @@ public class DungeonMaster : MonoBehaviour {
                 Statics.masterMind.pointCountdown = 5.0f;
             }
 
-            //spawn balls every x frames
-            if (timer3>(((float)Statics.masterMind.x)/60.0))
+            //spawn x balls every startx seconds
+            float interval = (((float)Statics.masterMind.startX) / ((float)Statics.masterMind.x));
+            if (timer3>interval)
 			{
 				for(int n=0;n<Statics.masterMind.phase;n++)// 4 balls at start, 5 after checkpoint 1, etc.
 				{
 					Instantiate(Enemy);// spawn ball
 				}
-				timer3=0.0f;
+				timer3-=interval;
 			}
+
+            if (curScore - subtractor >= 100)
+            {
+                subtractor += 100;
+                Statics.masterMind.game++;
+                Statics.masterMind.minX += 5;
+                Statics.masterMind.x = Statics.masterMind.minX;
+                Statics.masterMind.phase = Statics.masterMind.minPhase;
+            }
+
+
 			
-			if(timer2>1)//WIP - decrement x over time
+			if(timer2>2)//WIP - increment x over time
 			{
-				Statics.masterMind.x-=Statics.masterMind.game;
+                Statics.masterMind.x++;
 				timer2=timer2-1.0f;
 			}
 		}

--- a/Assets/Scripts/Enemy_Script.cs
+++ b/Assets/Scripts/Enemy_Script.cs
@@ -30,7 +30,7 @@ public class Enemy_Script : MonoBehaviour {
 	}
 	
 	// Update is called once per frame
-	void Update () {
+	void FixedUpdate () {
 		if(Statics.masterMind.gameState!=2)
 		{
 			tempVector = newPos;

--- a/Assets/Scripts/Player_Script.cs
+++ b/Assets/Scripts/Player_Script.cs
@@ -131,6 +131,7 @@ public class Player_Script : MonoBehaviour {
 			}
 			Statics.masterMind.hasPowerUp=false;
 			Statics.masterMind.powerUpCountdown=20;
+            dm.resetPhase();
 			Destroy(other.gameObject);
 		}
         else if (other.gameObject.tag == "Point")
@@ -149,8 +150,9 @@ public class Player_Script : MonoBehaviour {
 		GameOverStuff.SetActive(true);
 		PlayingStuff.SetActive(false);
 		Statics.masterMind.gameState = 2;
-		Statics.masterMind.x=60;
-		Statics.masterMind.phase=1;
+		Statics.masterMind.x=Statics.masterMind.startX;
+        Statics.masterMind.minX = Statics.masterMind.startX;
+        Statics.masterMind.phase=Statics.masterMind.minPhase;
         Statics.masterMind.game = 1;
 		#if UNITY_STANDALONE
 		Cursor.visible=true;

--- a/Assets/Scripts/Statics.cs
+++ b/Assets/Scripts/Statics.cs
@@ -7,9 +7,12 @@ using System.IO;
 
 public class Statics : MonoBehaviour {
     public readonly float[,] spawnPoints = { { 0.0f, 4.5f }, { 2.67f, 4.5f }, { -2.67f, 4.5f }, { 5.34f, 4.5f }, { -5.34f, 4.5f }, { 8.0f, 4.5f }, { -8.0f, 4.5f } };//Array of spawn Points
-    public int x = 60;
+    public int minX = 20;
+    public int startX = 20;
+    public int x = 20;
     public readonly float[,] cameraCorners = { {-15,15}, {15,-15} };//Coords of topLeft and bottomRight corners of FOV for destroying offScreen objects.
-	public int phase = 1;
+	public int phase = 4;
+    public int minPhase = 4;
     public int game = 1;
 	public int gameState =1;//0:menu 1:playing 2:gameOver
 	public float[] HighScores = {0,0,0,0,0,0,0,0,0,0};

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,12 +6,12 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Menu.unity
+    guid: e9a59470767d7e74489ba7dfe5d9dbd9
+  - enabled: 1
     path: Assets/MainGame.unity
     guid: f35e6ba1fb7bb8843a8177c025ff2c33
   - enabled: 1
     path: Assets/HighScores.unity
     guid: d4f636bc253d2d0488229caa2d003dd3
-  - enabled: 1
-    path: Assets/Menu.unity
-    guid: e9a59470767d7e74489ba7dfe5d9dbd9
   m_configObjects: {}


### PR DESCRIPTION
The number of bullets that spawn every 20 seconds increases from 20 by 1 every second for 30 seconds when the phase ends and it resets to 20. At every increment of 100 points, the minimum increases by 5.